### PR TITLE
[WIP] July 2018 Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ testscripts
 debug.log*
 node_modules
 package-lock.json
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ debug.log*
 node_modules
 package-lock.json
 __pycache__
+private_functions.py

--- a/main.py
+++ b/main.py
@@ -4214,7 +4214,9 @@ class NepBot(NepBotClass):
                                     cur.execute("UPDATE placed_bets SET prizePack = %s WHERE betid = %s AND userid = %s",
                                             [booster, betRow[0], winner["id"]])
                                 else:
-                                    pudding = minPrize + (maxPrize - minPrize) * (((numEntries - place) / (numEntries - 1)) ** 2)
+                                    pudding = minPrize + (maxPrize - minPrize) * (numEntries - place) / (numEntries - 1)
+                                    if place == 1:
+                                        pudding *= 1.3
                                     if isMarathonChannel:
                                         pudding *= 1.5
                                     if canWinBigPrizes and abs(winner["timedelta"]) < resultData["result"] / 120:

--- a/main.py
+++ b/main.py
@@ -2028,7 +2028,8 @@ class NepBot(NepBotClass):
 
         activeCommands = ["checkhand", "points", "freewaifu", "de", "disenchant", "buy", "booster", "trade", "lookup",
                           "alerts", "redeem", "upgrade", "search", "promote", "bet", "sets", "set", "giveaway",
-                          "bounty", "emotewar", "wars", "war", "vote", "profile", "owners", "freebie", "godimage", "freepacks"]
+                          "bounty", "emotewar", "wars", "war", "vote", "profile", "owners", "freebie", "godimage",
+                          "freepacks", "freepack", "pudding"]
 
         if sender not in blacklist and "bot" not in sender:
             activitymap[sender] = 0
@@ -3828,7 +3829,7 @@ class NepBot(NepBotClass):
                     config["promoschanged"] = "yes"
                     cur.execute("REPLACE INTO config(name, value) VALUES('promoschanged', 'yes')")
                 return
-            if command == "freepacks" or (command == "bet" and len(args) > 0 and args[0].lower() == "packs"):
+            if command == "freepacks" or command == "freepack" or (command == "bet" and len(args) > 0 and args[0].lower() == "packs"):
                 if len(args) > 0 and args[0].lower() in ["open", "claim", "redeem"]:
                     if len(args) < 2:
                         self.message(channel, "Usage: !freepacks open <booster name>", isWhisper)
@@ -4386,7 +4387,7 @@ class NepBot(NepBotClass):
                 return
             if command == "givefreepack" and sender in superadmins:
                 if len(args) < 2:
-                    self.message(channel, "Usage: !givefreepack <username> <booster name> [<amount>] (default 1)", isWhisper)
+                    self.message(channel, "Usage: !givefreepack <username> <booster name> [<amount> (default 1)]", isWhisper)
                     return
                 
                 if len(args) >= 3:

--- a/main.py
+++ b/main.py
@@ -154,7 +154,7 @@ def loadConfig():
                                  + ["rarity%dLength" % rarity for rarity in alertRarityRange] \
                                  + ["rarity%dSound" % rarity for rarity in alertRarityRange]
         waifu_regex = re.compile('(\[(?P<id>[0-9]+?)])?(?P<name>.+?) *- *(?P<series>.+) *- *(?P<rarity>[0-' + str(
-            int(config["numNormalRarities"]) - 1) + ']) *- *(?P<link>.+?)$')
+            int(config["numNormalRarities"]) + int(config["numSpecialRarities"]) - 1) + ']) *- *(?P<link>.+?)$')
         logger.debug("Alert config values: %s", str(validalertconfigvalues))
         logger.debug("Waifu regex: %s", str(waifu_regex))
         logger.info("Fetching admin list...")

--- a/main.py
+++ b/main.py
@@ -2269,14 +2269,24 @@ class NepBot(NepBotClass):
                     rewardInfo = cur.fetchone()
                     
                     if rewardInfo is None:
-                        self.message(channel, "Oops! The free reward database appears to be misconfigured. Please report this to an admin.", isWhisper)
+                        discordbody = {
+                            "username": "WTCG Admin", 
+                            "content" : "The free reward database is misconfigured, please fix it."
+                        }
+                        threading.Thread(target=sendAdminDiscordAlert, args=(discordbody,)).start()
+                        self.message(channel, "Could not retrieve your free reward, try again later.", isWhisper)
                         return
                         
                     # only one of the latter three rewards is allowed to be filled in, and there needs to be at least one reward.
                     cardRewardCount = sum([(1 if rewardInfo[n] is not None else 0) for n in range(1, 4)])
                     ovrRewardCount = sum([(1 if rewardInfo[n] is not None else 0) for n in range(4)])
                     if cardRewardCount > 1 or ovrRewardCount == 0:
-                        self.message(channel, "Oops! The free reward database appears to be misconfigured. Please report this to an admin.", isWhisper)
+                        discordbody = {
+                            "username": "WTCG Admin", 
+                            "content" : "The free reward database is misconfigured, please fix it."
+                        }
+                        threading.Thread(target=sendAdminDiscordAlert, args=(discordbody,)).start()
+                        self.message(channel, "Could not retrieve your free reward, try again later.", isWhisper)
                         return
                         
                     # can they take the reward at the current time?
@@ -2337,7 +2347,12 @@ class NepBot(NepBotClass):
                                     messageForHandUpgrade(tags['user-id'], tags['display-name'], self, channel, isWhisper)
                                 self.message(channel, "%s, you got your daily free reward: %sa %s booster - %s/booster?user=%s" % (tags['display-name'], pointsPrefix, rewardInfo[3], config['siteHost'], sender), isWhisper)
                             except InvalidBoosterException:
-                                self.message(channel, "Oops! The free reward database appears to be misconfigured. Please report this to an admin.", isWhisper)
+                                discordbody = {
+                                    "username": "WTCG Admin", 
+                                    "content" : "The free reward database is misconfigured, please fix it."
+                                }
+                                threading.Thread(target=sendAdminDiscordAlert, args=(discordbody,)).start()
+                                self.message(channel, "Could not retrieve your free reward, try again later.", isWhisper)
                                 return
 
                     cur.execute("UPDATE users SET lastFree = %s, rewardSeqSeed = %s, rewardSeqIndex = %s WHERE id = %s", [current_milli_time(), seed, index + 1, tags['user-id']])

--- a/main.py
+++ b/main.py
@@ -1438,8 +1438,9 @@ def openBooster(bot, userid, username, display_name, channel, isWhisper, packnam
                         [(boosterid, card) for card in cards])
 
         # alerts
+        alertname = display_name if display_name.lower() == username.lower() else "%s (%s)" % (display_name, username)
         for w in alertwaifus:
-            threading.Thread(target=sendDrawAlert, args=(channel, w, str(display_name))).start()
+            threading.Thread(target=sendDrawAlert, args=(channel, w, alertname)).start()
 
         return boosterid
 
@@ -4209,7 +4210,7 @@ class NepBot(NepBotClass):
                                     if abs(winner["timedelta"]) < 10:
                                         booster = config["almostExactBooster"]
                                     giveFreeBooster(winner["id"], booster)
-                                    msg = "You won a %s booster from the bet in %s's channel. Open it in any chat with !freepacks open %s ." % (booster, channel[1:], booster)
+                                    msg = "You won a %s booster from the bet in %s's channel. Open it in any chat with !freepacks open %s" % (booster, channel[1:], booster)
                                     prizeStrings.append("%s - %s pack" % (winner["name"], booster))
                                     cur.execute("UPDATE placed_bets SET prizePack = %s WHERE betid = %s AND userid = %s",
                                             [booster, betRow[0], winner["id"]])
@@ -4223,7 +4224,7 @@ class NepBot(NepBotClass):
                                         pudding *= 0.5
                                     pudding = round(pudding)
                                     addPudding(winner["id"], pudding)
-                                    msg = "You won %d pudding from the bet in %s's channel. Check and spend it with !pudding ." % (pudding, channel[1:])
+                                    msg = "You won %d pudding from the bet in %s's channel. Check and spend it with !pudding" % (pudding, channel[1:])
                                     prizeStrings.append("%s - %d pudding" % (winner["name"], pudding))
                                     cur.execute("UPDATE placed_bets SET prizePudding = %s WHERE betid = %s AND userid = %s",
                                             [pudding, betRow[0], winner["id"]])
@@ -4235,7 +4236,7 @@ class NepBot(NepBotClass):
                             runHours = resultData["result"] / 3600000.0
                             bcPrize = round(max(min(runHours, 5) * 20 + min(max(runHours - 5, 0), 5) * 30 + max(runHours - 10, 0) * 40, maxPrize / 2))
                             prizeStrings.append("%s (broadcaster) - %d pudding" % (channel[1:], bcPrize))
-                            whispers.append((channel, "You were rewarded %d pudding for running your recent bet. Check and spend it with !pudding ." % bcPrize))
+                            whispers.append((channel, "You were rewarded %d pudding for running your recent bet. Check and spend it with !pudding" % bcPrize))
                             # skip using addPudding to save a database lookup
                             cur.execute("UPDATE users SET puddingCurrent = puddingCurrent + %s WHERE name = %s", [bcPrize, channel[1:]])
                             
@@ -4397,9 +4398,9 @@ class NepBot(NepBotClass):
 
                     giveFreeBooster(userData[0], args[1], amount)
                     if amount > 1:
-                        self.message('#%s' % userData[1], "You were given %d free %s packs by an admin. Check them using !freepacks ." % (amount, args[1]), True)
+                        self.message('#%s' % userData[1], "You were given %d free %s packs by an admin. Check them using !freepacks" % (amount, args[1]), True)
                     else:
-                        self.message('#%s' % userData[1], "You were given a free %s pack by an admin. Open it using !freepacks open %s ." % (args[1], args[1]), True)
+                        self.message('#%s' % userData[1], "You were given a free %s pack by an admin. Open it using !freepacks open %s" % (args[1], args[1]), True)
 
                     self.message(channel, "Successfully gave %d %s packs to %s." % (amount, args[1], userData[1]), isWhisper)
                     return

--- a/main.py
+++ b/main.py
@@ -5274,7 +5274,7 @@ class NepBot(NepBotClass):
                             if do_global:
                                 cur.execute("UPDATE waifus SET image = %s WHERE id = %s", [hostedURL, waifuid])
                             else:
-                                cur.execute("UPDATE has_waifu SET custom_image = %s WHERE waifuid = %s AND userid = %s AND rarity = %s", [hostedURL, tags['user-id'], waifuid, godRarity])
+                                cur.execute("UPDATE has_waifu SET custom_image = %s WHERE waifuid = %s AND userid = %s AND rarity = %s", [hostedURL, waifuid, tags['user-id'], godRarity])
 
                             # log the change for posterity
                             insertArgs = [tags['user-id'], waifuid, args[2], do_global, tags['user-id'], current_milli_time()]
@@ -5420,7 +5420,7 @@ class NepBot(NepBotClass):
 
                             # notify them
                             self.message("#%s" % request[4], "Your global image change request for [%d] %s was accepted, the image has been changed." % (request[5], request[6]), True)
-                            self.message(channel, "Request accepted. The new image for [%d] %s is %s" % (request[5], request[6], hostedURL))
+                            self.message(channel, "Request accepted. The new image for [%d] %s is %s" % (request[5], request[6], hostedURL), isWhisper)
                         else:
                             # update it
                             try:
@@ -5439,7 +5439,7 @@ class NepBot(NepBotClass):
                             else:
                                 self.message("#%s" % request[4], "Your image change request for your copy of [%d] %s was accepted." % (request[5], request[6]), True)
 
-                            self.message(channel, "Request accepted. The new image for %s's copy of [%d] %s is %s" % (request[4], request[5], request[6], hostedURL))
+                            self.message(channel, "Request accepted. The new image for %s's copy of [%d] %s is %s" % (request[4], request[5], request[6], hostedURL), isWhisper)
                         return
 
 

--- a/main.py
+++ b/main.py
@@ -1351,8 +1351,8 @@ def openBooster(userid, username, channel, isWhisper, packname, buying=True):
         addSpending(userid, cost)
 
         # pity pull data update
-        cur.execute("UPDATE users SET pullScalingData = %s WHERE id = %s",
-                    [":".join(str(round(n)) for n in scalingData), userid])
+        cur.execute("UPDATE users SET pullScalingData = %s, eventTokens = eventTokens + %s WHERE id = %s",
+                    [":".join(str(round(n)) for n in scalingData), tokensDropped, userid])
 
         # insert opened booster
         cur.execute(

--- a/main.py
+++ b/main.py
@@ -785,7 +785,7 @@ def getWaifuRepresentationString(waifuid, baserarity=None, cardrarity=None, waif
 
     return retStr
 
-def sendSetAlert(channel, user, name, waifus, points, discord=True):
+def sendSetAlert(channel, user, name, waifus, pudding, discord=True):
     logger.info("Alerting for set claim %s", name)
     with busyLock:
         with db.cursor() as cur:
@@ -811,7 +811,7 @@ def sendSetAlert(channel, user, name, waifus, points, discord=True):
         {
             "type": "rich",
             "title": "{user} completed the set {name}!".format(user=str(user), name=name),
-            "description": "They gathered {waifus} and received {points} points as their reward.".format(waifus=naturalJoinNames(waifus), points=str(points)),
+            "description": "They gathered {waifus} and received {pudding} pudding as their reward.".format(waifus=naturalJoinNames(waifus), pudding=str(pudding)),
             "url": "https://twitch.tv/{name}".format(name=str(channel).replace("#", "").lower()),
             "color": int(config["rarity" + str(int(config["numNormalRarities"]) - 1) + "EmbedColor"]),
             "footer": {
@@ -4332,18 +4332,18 @@ class NepBot(NepBotClass):
 
                     # normal sets
                     cur.execute(
-                        "SELECT DISTINCT sets.id, sets.name, sets.reward FROM sets WHERE sets.claimed_by IS NULL AND sets.id NOT IN (SELECT DISTINCT setID FROM set_cards LEFT OUTER JOIN (SELECT * FROM has_waifu JOIN users ON has_waifu.userid = users.id WHERE users.id = %s) AS a ON waifuid = cardID JOIN sets ON set_cards.setID = sets.id JOIN waifus ON cardID = waifus.id WHERE a.name IS NULL)",
+                        "SELECT DISTINCT sets.id, sets.name, sets.rewardPudding FROM sets WHERE sets.claimed_by IS NULL AND sets.id NOT IN (SELECT DISTINCT setID FROM set_cards LEFT OUTER JOIN (SELECT * FROM has_waifu JOIN users ON has_waifu.userid = users.id WHERE users.id = %s) AS a ON waifuid = cardID JOIN sets ON set_cards.setID = sets.id JOIN waifus ON cardID = waifus.id WHERE a.name IS NULL)",
                         [tags["user-id"]])
                     rows = cur.fetchall()
                     for row in rows:
                         claimed += 1
                         cur.execute("UPDATE sets SET claimed_by = %s, claimed_at = %s WHERE sets.id = %s",
                                     [tags["user-id"], current_milli_time(), row[0]])
-                        addPoints(tags["user-id"], int(row[2]))
+                        addPudding(tags["user-id"], int(row[2]))
                         badgeid = addBadge(row[1], config["setBadgeDescription"], config["setBadgeDefaultImage"])
                         giveBadge(tags['user-id'], badgeid)
                         self.message(channel,
-                                     "Successfully claimed the Set {set} and rewarded {user} with {reward} points!".format(
+                                     "Successfully claimed the Set {set} and rewarded {user} with {reward} pudding!".format(
                                          set=row[1], user=tags["display-name"], reward=row[2]), isWhisper)
                         cur.execute(
                             "SELECT waifus.name FROM set_cards INNER JOIN waifus ON set_cards.cardID = waifus.id WHERE setID = %s",

--- a/main.py
+++ b/main.py
@@ -4214,7 +4214,7 @@ class NepBot(NepBotClass):
                                     cur.execute("UPDATE placed_bets SET prizePack = %s WHERE betid = %s AND userid = %s",
                                             [booster, betRow[0], winner["id"]])
                                 else:
-                                    pudding = minPrize + (maxPrize - minPrize) * (numEntries - place) / (numEntries - 1)
+                                    pudding = minPrize + (maxPrize - minPrize) * (((numEntries - place) / (numEntries - 1)) ** 2)
                                     if isMarathonChannel:
                                         pudding *= 1.5
                                     if canWinBigPrizes and abs(winner["timedelta"]) < resultData["result"] / 120:

--- a/main.py
+++ b/main.py
@@ -3019,47 +3019,50 @@ class NepBot(NepBotClass):
                             waifu["owned"] = " (not dropped yet)"
 
                         # bounty info
-                        with db.cursor() as cur:
-                            cur.execute(
-                                "SELECT COUNT(*), COALESCE(MAX(amount), 0) FROM bounties WHERE waifuid = %s AND status='open'",
-                                [waifu['id']])
-                            allordersinfo = cur.fetchone()
-
-                            if allordersinfo[0] > 0:
-                                cur.execute(
-                                    "SELECT amount FROM bounties WHERE userid = %s AND waifuid = %s AND status='open'",
-                                    [tags['user-id'], waifu['id']])
-                                myorderinfo = cur.fetchone()
-                                minfo = {"count": allordersinfo[0], "highest": allordersinfo[1]}
-                                if myorderinfo is not None:
-                                    minfo["mine"] = myorderinfo[0]
-                                    if myorderinfo[0] == allordersinfo[1]:
-                                        waifu[
-                                            "bountyinfo"] = " {count} current bounties, your bid is highest at {highest} points.".format(
-                                            **minfo)
-                                    else:
-                                        waifu[
-                                            "bountyinfo"] = "{count} current bounties, your bid of {mine} points is lower than the highest at {highest} points.".format(
-                                            **minfo)
-                                else:
-                                    waifu[
-                                        "bountyinfo"] = "{count} current bounties, the highest bid is {highest} points.".format(
-                                        **minfo)
-                            else:
-                                waifu["bountyinfo"] = "No current bounties on this waifu."
-
-                        # last pull
-                        if waifu["pulls"] == 0 or waifu["last_pull"] is None or waifu["base_rarity"] >= int(
-                                config["numNormalRarities"]):
+                        if waifu["base_rarity"] >= int(config["numNormalRarities"]):
+                            waifu["bountyinfo"] = ""
                             waifu["lp"] = ""
                         else:
-                            lpdiff = (current_milli_time() - waifu["last_pull"]) // 86400000
-                            if lpdiff == 0:
-                                waifu["lp"] = " Last pulled less than a day ago."
-                            elif lpdiff == 1:
-                                waifu["lp"] = " Last pulled 1 day ago."
+                            with db.cursor() as cur:
+                                cur.execute(
+                                    "SELECT COUNT(*), COALESCE(MAX(amount), 0) FROM bounties WHERE waifuid = %s AND status='open'",
+                                    [waifu['id']])
+                                allordersinfo = cur.fetchone()
+
+                                if allordersinfo[0] > 0:
+                                    cur.execute(
+                                        "SELECT amount FROM bounties WHERE userid = %s AND waifuid = %s AND status='open'",
+                                        [tags['user-id'], waifu['id']])
+                                    myorderinfo = cur.fetchone()
+                                    minfo = {"count": allordersinfo[0], "highest": allordersinfo[1]}
+                                    if myorderinfo is not None:
+                                        minfo["mine"] = myorderinfo[0]
+                                        if myorderinfo[0] == allordersinfo[1]:
+                                            waifu[
+                                                "bountyinfo"] = " {count} current bounties, your bid is highest at {highest} points.".format(
+                                                **minfo)
+                                        else:
+                                            waifu[
+                                                "bountyinfo"] = "{count} current bounties, your bid of {mine} points is lower than the highest at {highest} points.".format(
+                                                **minfo)
+                                    else:
+                                        waifu[
+                                            "bountyinfo"] = "{count} current bounties, the highest bid is {highest} points.".format(
+                                            **minfo)
+                                else:
+                                    waifu["bountyinfo"] = "No current bounties on this waifu."
+
+                            # last pull
+                            if waifu["pulls"] == 0 or waifu["last_pull"] is None:
+                                waifu["lp"] = ""
                             else:
-                                waifu["lp"] = " Last pulled %d days ago." % lpdiff
+                                lpdiff = (current_milli_time() - waifu["last_pull"]) // 86400000
+                                if lpdiff == 0:
+                                    waifu["lp"] = " Last pulled less than a day ago."
+                                elif lpdiff == 1:
+                                    waifu["lp"] = " Last pulled 1 day ago."
+                                else:
+                                    waifu["lp"] = " Last pulled %d days ago." % lpdiff
 
                         self.message(channel,
                                      '[{id}][{rarity}] {name} from {series} - {image}{owned}. {bountyinfo}{lp}'.format(

--- a/main.py
+++ b/main.py
@@ -5079,12 +5079,6 @@ class NepBot(NepBotClass):
                         if waifu["base_rarity"] == godRarity:
                             self.message(channel, "Base god rarity waifus cannot have their picture changed!", isWhisper)
                             return
-                        
-                        try:
-                            validateImageURL(args[2])
-                        except ValueError as ex:
-                            self.message(channel, "Invalid link specified. %s" % str(ex), isWhisper)
-                            return
 
                         if canManageImages:
                             # automatically do the change
@@ -5106,6 +5100,14 @@ class NepBot(NepBotClass):
                             self.message(channel, "Image change processed successfully.", isWhisper)
                             return
                         else:
+                            try:
+                                validateImageURL(args[2])
+                            except ValueError as ex:
+                                self.message(channel, "Invalid link specified. %s" % str(ex), isWhisper)
+                                return
+                            except Exception:
+                                self.message(channel, "There was an unknown problem with the link you specified. Please try again later.", isWhisper)
+                                return
                             # cancel any old pending requests for this waifu
                             cur.execute("UPDATE godimage_requests SET state = 'cancelled', updated = %s WHERE waifuid = %s AND state = 'pending'", [current_milli_time(), waifuid])
 

--- a/main.py
+++ b/main.py
@@ -4197,6 +4197,7 @@ class NepBot(NepBotClass):
                             # calculate first run of prizes
                             minPrize = int(config["betMinPrize"])
                             maxPrize = int(config["betMaxPrize"]) * min(1 + numEntries/10, 2)
+                            bbReward = int(config["baseBroadcasterReward"])
                             canWinBigPrizes = resultData["result"] >= 1800000
                             whispers = []
                             prizeStrings = []
@@ -4214,7 +4215,7 @@ class NepBot(NepBotClass):
                                     cur.execute("UPDATE placed_bets SET prizePack = %s WHERE betid = %s AND userid = %s",
                                             [booster, betRow[0], winner["id"]])
                                 else:
-                                    pudding = minPrize + (maxPrize - minPrize) * (numEntries - place) / (numEntries - 1)
+                                    pudding = minPrize + (maxPrize - minPrize) * (numEntries - place) / (numEntries - 1) / (1.4 if place > numEntries / 2 else 1)
                                     if place == 1:
                                         pudding *= 1.3
                                     if isMarathonChannel:
@@ -4235,7 +4236,7 @@ class NepBot(NepBotClass):
                             # run length in hours * 20, rounded to nearest whole pudding
                             # scales up a bit as the hours go on
                             runHours = resultData["result"] / 3600000.0
-                            bcPrize = round(max(min(runHours, 5) * 30 + min(max(runHours - 5, 0), 5) * 45 + max(runHours - 10, 0) * 60, maxPrize / 2))
+                            bcPrize = round(max(min(runHours, 5) * bbReward + min(max(runHours - 5, 0), 5) * bbReward * 1.5 + max(runHours - 10, 0) * bbReward * 2, maxPrize / 2))
                             prizeStrings.append("%s (broadcaster) - %d pudding" % (channel[1:], bcPrize))
                             whispers.append((channel, "You were rewarded %d pudding for running your recent bet. Check and spend it with !pudding" % bcPrize))
                             # skip using addPudding to save a database lookup

--- a/main.py
+++ b/main.py
@@ -2179,6 +2179,16 @@ class NepBot(NepBotClass):
                         if booster is None:
                             self.message(channel, "Invalid booster specified.", isWhisper)
                             return
+                        # can they actually open it?
+                        cur.execute("SELECT COUNT(*) FROM boosters_opened WHERE userid = %s AND status = 'open'",
+                                [tags['user-id']])
+                        boosteropen = cur.fetchone()[0] or 0
+
+                        if boosteropen > 0:
+                            self.message(channel,
+                                        "%s, you have an open booster already! !booster show to check it." %
+                                        tags['display-name'], isWhisper)
+                            return
                         cost = math.ceil(int(booster[1])/int(config["puddingExchangeRate"]))
                         if not hasPudding(tags['user-id'], cost):
                             self.message(channel, "%s, you can't afford a %s booster. They cost %d pudding." % (tags['display-name'], booster[0], cost), isWhisper)

--- a/main.py
+++ b/main.py
@@ -2269,10 +2269,7 @@ class NepBot(NepBotClass):
                         return
                         
                     # can they take the reward at the current time?
-                    if rewardInfo[3] is not None and hasPack:
-                        self.message(channel, "%s, your next reward is a booster and you have one open!" % tags['display-name'], isWhisper)
-                        return
-                    elif (rewardInfo[1] is not None or rewardInfo[2] is not None) and hasPack and not spaceInHand:
+                    if (rewardInfo[1] is not None or rewardInfo[2] is not None) and hasPack and not spaceInHand:
                         self.message(channel, "%s, your hand is full and you have a booster open!" % tags['display-name'], isWhisper)
                         return
                         
@@ -2318,14 +2315,19 @@ class NepBot(NepBotClass):
                        
                             
                     if rewardInfo[3] is not None:
-                        try:
-                            packid = openBooster(self, tags['user-id'], sender, tags['display-name'], channel, isWhisper, rewardInfo[3], False)
-                            if checkHandUpgrade(tags['user-id']):
-                                messageForHandUpgrade(tags['user-id'], tags['display-name'], self, channel, isWhisper)
-                            self.message(channel, "%s, you got your daily free reward: %sa booster - %s/booster?user=%s" % (tags['display-name'], pointsPrefix, config['siteHost'], sender), isWhisper)
-                        except InvalidBoosterException:
-                            self.message(channel, "Oops! The free reward database appears to be misconfigured. Please report this to an admin.", isWhisper)
-                            return
+                        if hasPack:
+                            # send the pack to freepacks
+                            giveFreeBooster(tags['user-id'], rewardInfo[3])
+                            self.message(channel, "%s, you got your daily free reward: %sa %s booster (sent to !freepacks)" % (tags['display-name'], pointsPrefix, rewardInfo[3]), isWhisper)
+                        else:
+                            try:
+                                packid = openBooster(self, tags['user-id'], sender, tags['display-name'], channel, isWhisper, rewardInfo[3], False)
+                                if checkHandUpgrade(tags['user-id']):
+                                    messageForHandUpgrade(tags['user-id'], tags['display-name'], self, channel, isWhisper)
+                                self.message(channel, "%s, you got your daily free reward: %sa %s booster - %s/booster?user=%s" % (tags['display-name'], pointsPrefix, rewardInfo[3], config['siteHost'], sender), isWhisper)
+                            except InvalidBoosterException:
+                                self.message(channel, "Oops! The free reward database appears to be misconfigured. Please report this to an admin.", isWhisper)
+                                return
 
                     cur.execute("UPDATE users SET lastFree = %s, rewardSeqSeed = %s, rewardSeqIndex = %s WHERE id = %s", [current_milli_time(), seed, index + 1, tags['user-id']])
                     return

--- a/main.py
+++ b/main.py
@@ -5047,10 +5047,16 @@ class NepBot(NepBotClass):
                         self.message(channel, "Usage: !godimage change[global] <id> <link>", isWhisper)
                         return
 
+                    waifu = getWaifuById(waifuid)
+
                     with db.cursor() as cur:
                         cur.execute("SELECT COUNT(*) FROM has_waifu WHERE userid = %s AND waifuid = %s AND rarity = %s", [tags['user-id'], waifuid, godRarity])
                         if cur.fetchone()[0] == 0:
                             self.message(channel, "You don't own that waifu at god rarity!", isWhisper)
+                            return
+
+                        if waifu["base_rarity"] == godRarity:
+                            self.message(channel, "Base god rarity waifus cannot have their picture changed!", isWhisper)
                             return
                         
                         try:
@@ -5087,7 +5093,6 @@ class NepBot(NepBotClass):
                             cur.execute("INSERT INTO godimage_requests (requesterid, waifuid, image, is_global, state, created) VALUES(%s, %s, %s, %s, 'pending', %s)", insertArgs)
 
                             # notify the discordhook of the new request
-                            waifu = getWaifuById(waifuid)
                             discordArgs = {"user": tags['display-name'], "id": waifuid, "name": waifu["name"], "image": args[2], "type": "a global" if do_global else "an"}
                             discordbody = {
                                 "username": "WTCG Admin", 

--- a/main.py
+++ b/main.py
@@ -2185,7 +2185,7 @@ class NepBot(NepBotClass):
                             return
                         takePudding(tags['user-id'], cost)
                         try:
-                            openBooster(self, tags['user-id'], sender, tags['display-name'], channel, isWhisper, booster[0])
+                            openBooster(self, tags['user-id'], sender, tags['display-name'], channel, isWhisper, booster[0], False)
                             if checkHandUpgrade(tags['user-id']):
                                 messageForHandUpgrade(tags['user-id'], tags['display-name'], self, channel, isWhisper)
                             self.message(channel, "%s, you open a %s booster for %d pudding: %s/booster?user=%s" % (tags['display-name'], booster[0], cost, config["siteHost"], sender), isWhisper)

--- a/main.py
+++ b/main.py
@@ -2070,8 +2070,7 @@ class NepBot(NepBotClass):
     def message(self, channel, message, isWhisper=False):
         logger.debug("sending message %s %s %s" % (channel, message, "Y" if isWhisper else "N"))
         if isWhisper:
-            pass
-            #super().message("#jtv", "/w " + str(channel).replace("#", "") + " " + str(message))
+            super().message("#jtv", "/w " + str(channel).replace("#", "") + " " + str(message))
         elif not silence:
             super().message(channel, message)
         else:

--- a/main.py
+++ b/main.py
@@ -2713,6 +2713,11 @@ class NepBot(NepBotClass):
                         except ValueError:
                             self.message(channel, "Only whole numbers/IDs + rarities please.", isWhisper)
                             return
+                            
+                    # actual specials can't be traded
+                    if have["rarity"] == firstSpecialRarity or want["rarity"] == firstSpecialRarity:
+                        self.message(channel, "Sorry, cards of that rarity cannot be traded.", isWhisper)
+                        return
 
                     payup = ourid
                     firstSpecialRarity = int(config["numNormalRarities"])
@@ -2721,7 +2726,7 @@ class NepBot(NepBotClass):
                     if not canTradeDirectly:
                         if have["rarity"] >= firstSpecialRarity or want["rarity"] >= firstSpecialRarity:
                             self.message(channel,
-                                         "Sorry, special-rarity cards can only be traded for other special-rarity cards.",
+                                         "Sorry, irregular rarity cards can only be traded for other irregular rarity cards.",
                                          isWhisper=isWhisper)
                             return
                         if len(args) != 4:

--- a/main.py
+++ b/main.py
@@ -2189,8 +2189,13 @@ class NepBot(NepBotClass):
                                 messageForHandUpgrade(tags['user-id'], tags['display-name'], self, channel, isWhisper)
                             self.message(channel, "%s, you open a %s booster for %d pudding: %s/booster?user=%s" % (tags['display-name'], booster[0], cost, config["siteHost"], sender), isWhisper)
                         except InvalidBoosterException:
+                            discordbody = {
+                                "username": "WTCG Admin", 
+                                "content" : "Booster type %s is broken, please fix it." % booster[0]
+                            }
+                            threading.Thread(target=sendAdminDiscordAlert, args=(discordbody,)).start()
                             self.message(channel,
-                                        "Go tell an admin that this booster type is broken.",
+                                        "There was an error processing your booster, please try again later.",
                                         isWhisper)
                             return
                 elif subcmd == "list":
@@ -3341,12 +3346,6 @@ class NepBot(NepBotClass):
                     cur.close()
                     return
 
-                if len(redeemablerows) > 1:
-                    self.message(channel, "Go tell an admin that token %s is broken (duplicate token name)." % args[0],
-                                 isWhisper)
-                    cur.close()
-                    return
-
                 redeemdata = redeemablerows[0]
 
                 # already claimed by this user?
@@ -3383,9 +3382,14 @@ class NepBot(NepBotClass):
                             messageForHandUpgrade(tags['user-id'], tags['display-name'], self, channel, isWhisper)
                         received.append("a free booster: %s/booster?user=%s" % (config["siteHost"], sender))
                     except InvalidBoosterException:
+                        discordbody = {
+                            "username": "WTCG Admin", 
+                            "content" : "Booster type %s is broken, please fix it." % redeemdata[3]
+                        }
+                        threading.Thread(target=sendAdminDiscordAlert, args=(discordbody,)).start()
                         self.message(channel,
-                                     "Go tell an admin that token %s is broken (invalid booster attached)." % args[0],
-                                     isWhisper)
+                                    "There was an error processing your redeem, please try again later.",
+                                    isWhisper)
                         cur.close()
                         return
 
@@ -3851,8 +3855,13 @@ class NepBot(NepBotClass):
                             cur.execute("UPDATE freepacks SET remaining = remaining - 1 WHERE userid = %s AND boostername = %s", [tags['user-id'], args[1]])
                             self.message(channel, "%s, you open a free %s booster: %s/booster?user=%s" % (tags['display-name'], result[1], config["siteHost"], sender), isWhisper)
                         except InvalidBoosterException:
+                            discordbody = {
+                                "username": "WTCG Admin", 
+                                "content" : "Booster type %s is broken, please fix it." % args[1]
+                            }
+                            threading.Thread(target=sendAdminDiscordAlert, args=(discordbody,)).start()
                             self.message(channel,
-                                        "Go tell an admin that this booster type is broken.",
+                                        "There was an error opening your free pack, please try again later.",
                                         isWhisper)
                             return
                         return

--- a/main.py
+++ b/main.py
@@ -2693,7 +2693,7 @@ class NepBot(NepBotClass):
                         [currTime, currTime - 86400000])
                     if len(args) < 2:
                         self.message(channel,
-                                     "Usage: !trade <check/accept/decline> <user> OR !trade <user> <have> <want> [points]",
+                                     "Usage: !trade <check/accept/decline> <user> OR !trade <user> <have> <want>",
                                      isWhisper=isWhisper)
                         return
                     subarg = args[0].lower()
@@ -2715,7 +2715,7 @@ class NepBot(NepBotClass):
 
                         if trade is None:
                             self.message(channel,
-                                         otherparty + " did not send you a trade. Send one with !trade " + otherparty + " <have> <want> [points]",
+                                         otherparty + " did not send you a trade. Send one with !trade " + otherparty + " <have> <want>",
                                          isWhisper=isWhisper)
                             return
 
@@ -2848,9 +2848,9 @@ class NepBot(NepBotClass):
                             self.message(channel, "Trade executed!", isWhisper=isWhisper)
                             return
 
-                    if len(args) not in [3, 4]:
+                    if len(args) < 3:
                         self.message(channel,
-                                     "Usage: !trade <accept/decline> <user> OR !trade <user> <have> <want> [points]",
+                                     "Usage: !trade <accept/decline> <user> OR !trade <user> <have> <want>",
                                      isWhisper=isWhisper)
                         return
 
@@ -2903,14 +2903,6 @@ class NepBot(NepBotClass):
                     except ValueError:
                         self.message(channel, "Only whole numbers/IDs + rarities please.", isWhisper)
                         return
-
-                    points = 0
-                    if len(args) == 4:
-                        try:
-                            points = int(args[3])
-                        except ValueError:
-                            self.message(channel, "Only whole numbers/IDs + rarities please.", isWhisper)
-                            return
                             
                     # actual specials can't be traded
                     firstSpecialRarity = int(config["numNormalRarities"])
@@ -2921,36 +2913,18 @@ class NepBot(NepBotClass):
                     payup = ourid
                     canTradeDirectly = (want["rarity"] == have["rarity"]) or (
                             want["rarity"] >= firstSpecialRarity and have["rarity"] >= firstSpecialRarity)
+                    points = 0
                     if not canTradeDirectly:
                         if have["rarity"] >= firstSpecialRarity or want["rarity"] >= firstSpecialRarity:
                             self.message(channel,
                                          "Sorry, irregular rarity cards can only be traded for other irregular rarity cards.",
                                          isWhisper=isWhisper)
                             return
-                        if len(args) != 4:
-                            self.message(channel,
-                                         "To trade waifus of different rarities, please append a point value the owner of the lower tier card has to pay to the command to make the trade fair. (see !help)",
-                                         isWhisper=isWhisper)
-                            return
                         highercost = int(config["rarity" + str(max(have["rarity"], want["rarity"])) + "Value"])
                         lowercost = int(config["rarity" + str(min(have["rarity"], want["rarity"])) + "Value"])
-                        costdiff = highercost - lowercost
-                        mini = int(costdiff / 2)
-                        maxi = int(costdiff)
-                        if points < mini:
-                            self.message(channel, "Minimum points to trade this difference in rarity is " + str(mini),
-                                         isWhisper=isWhisper)
-                            return
-                        if points > maxi:
-                            self.message(channel, "Maximum points to trade this difference in rarity is " + str(maxi),
-                                         isWhisper=isWhisper)
-                            return
+                        points = highercost - lowercost
                         if want["rarity"] < have["rarity"]:
                             payup = otherid
-
-                    elif points > 0:
-                        self.message(channel, "You cannot attach points on same-rarity trades.", isWhisper)
-                        return
 
                     # cancel any old trades with this pairing
                     cur.execute(
@@ -4249,7 +4223,7 @@ class NepBot(NepBotClass):
                             # run length in hours * 20, rounded to nearest whole pudding
                             # scales up a bit as the hours go on
                             runHours = resultData["result"] / 3600000.0
-                            bcPrize = round(max(min(runHours, 5) * 20 + min(max(runHours - 5, 0), 5) * 30 + max(runHours - 10, 0) * 40, maxPrize / 2))
+                            bcPrize = round(max(min(runHours, 5) * 30 + min(max(runHours - 5, 0), 5) * 45 + max(runHours - 10, 0) * 60, maxPrize / 2))
                             prizeStrings.append("%s (broadcaster) - %d pudding" % (channel[1:], bcPrize))
                             whispers.append((channel, "You were rewarded %d pudding for running your recent bet. Check and spend it with !pudding" % bcPrize))
                             # skip using addPudding to save a database lookup

--- a/main.py
+++ b/main.py
@@ -813,11 +813,11 @@ def getWaifuById(id):
     except ValueError:
         return None
     cur = db.cursor()
-    cur.execute("SELECT id, Name, image, base_rarity, series, can_lookup, pulls, last_pull FROM waifus WHERE id=%s",
+    cur.execute("SELECT id, Name, image, base_rarity, series, can_lookup, pulls, last_pull, can_favourite FROM waifus WHERE id=%s",
                 [id])
     row = cur.fetchone()
     ret = {"id": row[0], "name": row[1], "image": row[2], "base_rarity": row[3], "series": row[4], "can_lookup": row[5],
-           "pulls": row[6], "last_pull": row[7]}
+           "pulls": row[6], "last_pull": row[7], "can_favourite": row[8]}
     cur.close()
     # print("Fetched Waifu from id: " + str(ret))
     return ret
@@ -4914,6 +4914,9 @@ class NepBot(NepBotClass):
                         self.message(channel, tags[
                             "display-name"] + ", sorry, but that Waifu doesn't exist. Try a different one!",
                                      isWhisper)
+                        return
+                    elif newFavW["can_favourite"] == 0:
+                        self.message(channel, "%s, sorry, but that Waifu can't be set as your favourite. Try a different one!" % tags['display-name'], isWhisper)
                         return
                     elif hasOrIsLowRarity:
                         self.message(channel, "Updated your favourite Waifu to be " + newFavW["name"] + "! naroDesu",

--- a/main.py
+++ b/main.py
@@ -4257,6 +4257,41 @@ class NepBot(NepBotClass):
                 else:
                     self.message(channel, "Debug mode is off. Debug command disabled.")
                 return
+            if command == "givefreepack" and sender in superadmins:
+                if len(args) < 2:
+                    self.message(channel, "Usage: !givefreepack <username> <booster name> [<amount>] (default 1)", isWhisper)
+                    return
+                
+                if len(args) >= 3:
+                    try:
+                        amount = int(args[2])
+                    except ValueError:
+                        self.message(channel, "Invalid amount specified.", isWhisper)
+                        return
+                else:
+                    amount = 1
+
+                with db.cursor() as cur:
+                    cur.execute("SELECT id, name FROM users WHERE name = %s", [args[0]])
+                    userData = cur.fetchone()
+                    if userData is None:
+                        self.message(channel, "Invalid username specified.", isWhisper)
+                        return
+
+                    cur.execute("SELECT COUNT(*) FROM boosters WHERE name = %s", [args[1]])
+                    if cur.fetchone()[0] == 0:
+                        self.message(channel, "Invalid booster name specified.", isWhisper)
+                        return
+
+                    giveFreeBooster(userData[0], args[1], amount)
+                    if amount > 1:
+                        self.message('#%s' % userData[1], "You were given %d free %s packs by an admin. Check them using !freepacks ." % (amount, args[1]), True)
+                    else:
+                        self.message('#%s' % userData[1], "You were given a free %s pack by an admin. Open it using !freepacks open %s ." % (args[1], args[1]), True)
+
+                    self.message(channel, "Successfully gave %d %s packs to %s." % (amount, args[1], userData[1]), isWhisper)
+                    return
+                    
             if command == "nepcord":
                 self.message(channel,
                              "To join the discussion in the official Waifu TCG Discord Channel, go to %s/discord" %

--- a/main.py
+++ b/main.py
@@ -1713,7 +1713,7 @@ class NepBot(NepBotClass):
                     # pudding expiry?
                     now = datetime.datetime.now()
                     ymdNow = now.strftime("%Y-%m-%d")
-                    if ymdNow != config["last_pudding_check"]:
+                    if ymdNow > config["last_pudding_check"]:
                         logger.debug("Processing pudding expiry...")
                         config["last_pudding_check"] = ymdNow
                         cur.execute("UPDATE config SET value = %s WHERE name = 'last_pudding_check'", [ymdNow])
@@ -2493,7 +2493,7 @@ class NepBot(NepBotClass):
             if command == "booster":
                 if len(args) < 1:
                     self.message(channel,
-                                 "Usage: !booster buy <%s> OR !booster select <take/disenchant> (for each waifu) OR !booster show" % visiblepacks,
+                                 "Usage: !booster list OR !booster buy <%s> OR !booster select <take/disenchant> (for each waifu) OR !booster show" % visiblepacks,
                                  isWhisper=isWhisper)
                     return
 
@@ -2633,6 +2633,15 @@ class NepBot(NepBotClass):
                                 [current_milli_time(), boosterinfo[0]])
                     cur.close()
                     return
+
+                if cmd == "list":
+                    with db.cursor() as cur:
+                        cur.execute("SELECT name, cost FROM boosters WHERE listed = 1 AND buyable = 1 ORDER BY sortIndex ASC")
+                        boosters = cur.fetchall()
+                        boosterInfo = ", ".join("%s / %d points" % (row[0], row[1]) for row in boosters)
+                        self.message(channel, "Current buyable packs: %s. !booster buy <name> to buy a booster with points." % boosterInfo, isWhisper)
+                    return
+                
                 if cmd == "buy":
                     if boosterinfo is not None:
                         self.message(channel,

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "nepBot",
   "version": "0.0.1",
   "dependencies": {
+    "async": "^2.6.1",
     "mysql": "^2.15.0",
     "request": "^2.83.0"
   }

--- a/smartsets.htm
+++ b/smartsets.htm
@@ -112,7 +112,8 @@
         for (set of data.sets) {
             title = user !== "null" ? set.name + " (" + set.cardsOwned + "/" + set.totalCards + ")" : set.name;
             buttons += buttonTemplate.replace(/{ID}/g, set.id).replace(/{UNIQ}/g, uniqid).replace(/{TITLE}/g, title);
-            setbox = '<div class="collapse" id="set' + set.id + '-' + uniqid + '"><div class="card card-body" style="display: inline-block;">Reward: ' + set.reward + '<br />';
+            reward = set.rewardPudding + ' pudding';
+            setbox = '<div class="collapse" id="set' + set.id + '-' + uniqid + '"><div class="card card-body" style="display: inline-block;">Reward: ' + reward + '<br />';
             for (row of set.cards) {
                 let card = cardtemplate;
                 card = card.replace(/{ID}/g, row.id.toString());

--- a/website.js
+++ b/website.js
@@ -163,7 +163,8 @@ let bootstrapboostereventtoken = '<div class="card card-tcg card-{RARITY}">' +
     '</div>' +
     '<div class="card-footer text-center">' +
     '<div class="card-info">' +
-    '<b>{CARDNAME}</b>' +
+    '<b>{CARDNAME}</b><br />' +
+    '<small>(sent directly to account)</small>' + 
     '</div>' +
     '</div>' +
     '</div>';
@@ -434,7 +435,7 @@ function claimedsets(req, res, query) {
 function getCardHtml(template, row) {
     template = template.replace(/{AMOUNTHOLDER}/g, row.amount > 1 ? bootstraphandamtholder : '');
     template = template.replace(/{PROMOTEDHOLDER}/g, row.rarity > row.base_rarity ? bootstraphandpromoholder : '');
-    if (row.rarity > row.base_rarity) {
+    if (row.rarity > row.base_rarity && row.rarity < 8) {
         template = template.replace(/{STARS}/g, "★".repeat(row.rarity - row.base_rarity));
     }
     else {

--- a/website.js
+++ b/website.js
@@ -442,7 +442,7 @@ function getCardHtml(template, row) {
         template = template.replace(/{STARS}/g, "");
     }
     template = template.replace(/{ID}/g, row.id.toString());
-    template = template.replace(/{IMAGE}/g, row.image.toString());
+    template = template.replace(/{IMAGE}/g, (row.custom_image || row.image).toString());
     template = template.replace(/{CARDNAME}/g, row.Name.toString());
     template = template.replace(/{SERIES}/g, row.series.toString());
     template = template.replace(/{RARITY}/g, getRarityName(row.rarity));
@@ -457,7 +457,7 @@ function bootstraphand(req, res, query) {
         return;
     }
 
-    con.query("SELECT waifus.*, rarity, amount FROM waifus JOIN has_waifu ON waifus.id = has_waifu.waifuid JOIN users ON " +
+    con.query("SELECT waifus.*, rarity, amount, custom_image FROM waifus JOIN has_waifu ON waifus.id = has_waifu.waifuid JOIN users ON " +
         "has_waifu.userid = users.id WHERE users.name = ? ORDER BY (has_waifu.rarity < 8) DESC, waifus.id ASC, has_waifu.rarity ASC", query.user, function (err, result) {
         if (err) throw err;
         let wantJSON = false;
@@ -496,7 +496,7 @@ function bootstraphand(req, res, query) {
                         "id": row.id,
                         "Name": row.Name,
                         "series": row.series,
-                        "image": row.image,
+                        "image": row.custom_image || row.image,
                         "base_rarity": row.base_rarity,
                         "rarity": row.rarity,
                         "amount": row.amount
@@ -836,7 +836,7 @@ function profile(req, res, query) {
                 badge = badge.replace(/{CARDNAME}/g, row.name);
                 badges += badge;
             }
-            con.query("SELECT waifus.id, waifus.Name, waifus.image, waifus.base_rarity, waifus.series, has_waifu.rarity FROM waifus LEFT JOIN has_waifu ON (has_waifu.waifuid = waifus.id AND has_waifu.userid = ?) WHERE id = ? ORDER BY has_waifu.rarity DESC LIMIT 1", [userID, resultOuter[0].favourite], function (err, resultInner) {
+            con.query("SELECT waifus.id, waifus.Name, waifus.image, waifus.base_rarity, waifus.series, has_waifu.rarity, has_waifu.custom_image FROM waifus LEFT JOIN has_waifu ON (has_waifu.waifuid = waifus.id AND has_waifu.userid = ?) WHERE id = ? ORDER BY has_waifu.rarity DESC LIMIT 1", [userID, resultOuter[0].favourite], function (err, resultInner) {
                 if (err) throw err;
 
                 let row = resultInner[0];

--- a/website.js
+++ b/website.js
@@ -767,13 +767,13 @@ function profile(req, res, query) {
                 badge = badge.replace(/{CARDNAME}/g, row.name);
                 badges += badge;
             }
-            con.query("SELECT waifus.id, waifus.Name, waifus.image, waifus.base_rarity, waifus.series FROM waifus WHERE id = ?", resultOuter[0].favourite, function (err, resultInner) {
+            con.query("SELECT waifus.id, waifus.Name, waifus.image, waifus.base_rarity, waifus.series, has_waifu.rarity FROM waifus LEFT JOIN has_waifu ON (has_waifu.waifuid = waifus.id AND has_waifu.userid = ?) WHERE id = ? ORDER BY has_waifu.rarity DESC LIMIT 1", [userID, resultOuter[0].favourite], function (err, resultInner) {
                 if (err) throw err;
 
                 let row = resultInner[0];
 
                 row.amount = 1;
-                row.rarity = row.base_rarity;
+                row.rarity = (row.rarity && row.rarity > row.base_rarity) ? row.rarity : row.base_rarity;
 
                 let card = bootstraphandcard;
 

--- a/website.js
+++ b/website.js
@@ -514,7 +514,7 @@ function bootstraphand(req, res, query) {
                 }
                 if(resultTokens[0].eventTokens > 0) {
                     let card = bootstraphandeventtoken;
-                    card = getCardHtml(card, { "id": "", "Name": "<b>" + config.eventTokenName + "</b>", "series": "", "image": config.eventTokenImage, "base_rarity": 9, "rarity": 9, "amount": resultTokens[0].eventTokens});
+                    card = getCardHtml(card, { "id": "", "Name": config.eventTokenName, "series": "", "image": config.eventTokenImage, "base_rarity": 9, "rarity": 9, "amount": resultTokens[0].eventTokens});
                     cards += card;
                 }
                 res.write(bootstraphandtpl.replace(/{CARDS}/g, cards).replace(/{NAME}/g, query.user));


### PR DESCRIPTION
**Second currency**
- [x] Database fields
- [x] Second currency amount displayed when you use !points (and maybe an alias of its name as well)
- [x] Second currency expires at the start of the month 2 after the one it was earned (so if earned from August 1-31, would expire in early October)
- [x] Purchase packs with second currency (savings closest to expiration are used first)
- [x] Bets pay out in second currency
- [x] Sets pay out in second currency

**System to support Anniversary packs**
- [x] Database field for event tokens
- [x] Each pack has a chance to replace a card with an event token which is credited to account immediately
- [x] Event tokens shown in visual display of pack but do not contribute towards keep/DE list
- [x] Database settings for name, image, possibly other aspects

**God image request system**
- [x] !godimage command with the following:
  - [x] request/requestglobal <waifu id> - places the request from user side, does preliminary checks (url must be valid from imgur or some other trusted host, mime type, possibly aspect ratio). If requestglobal is used, submits the image as a candidate to be used for all copies, otherwise just your own. This command should send a notification to a new `adminDiscordHook` when successfully invoked. Should also warn user if image submitted is >= 2MB so they can choose to adjust it rather than being unwittingly subjected to the auto downscale.
  - [x] list - check your own pending requests
  - [x] cancel <id> - cancels a particular request
  - [x] queue - lists pending request ID numbers
  - [x] check <id> - shows the details of a particular request
  - [x] acceptsingle <id> - accepts a particular request, but only as the image for that user's copy, even if the user requested a global change.
  - [x] acceptglobal <id> - accepts a request for a global change and does the global change. If used on a non-global request, errors out.
- [x] When a request is accepted,
  - [x] download it (and error out if download fails)
  - [x] double check that the properties tested on submission haven't become invalid
  - [x] downscale to under 2mb while above 2mb
  - [x] reupload to our own image host
  - [x] send appropriate whisper notification
- [x] Requests only usable on cards with a promoted god copy present in hand
- [x] Requests cancelled when (send whisper to let the user know as well)
  - [x] copy is disenchanted
  - [x] copy is traded

**Profile pics / special cards cleanup**
- [x] Block trading specials entirely
- [x] Show promoted rarity if a promoted copy of profile favorite is present in hand
- [x] Make a flag for certain cards to not be allowed as profile favorite at all
- [x] Remove card from profile favorite if:
  - [x] Promo/special is disenchanted
  - [x] Promo is traded away
  - [x] Card is raritychanged to promo or special and not present in hand

**Centralized free packs system**
- [x] Database table for freepacks inventory
- [x] Freepacks command:
  - [x] base command (or list) lists your current inventory of free packs, like current !bet packs
  - [x] !freepacks open/redeem <packname> to cash one in, so as to remove the clutter in the token system
- [x] Any remaining bet packs (tier 6/7, probably) are sent to freepacks system
- [x] Packs given out by freebie can be sent there.
- [x] Add system to auto-dispense a certain free pack upon getting a "meme pack" situation (75/625 jumbo, 420 standard) and notify the user of such