### PR TITLE
Fix that single godimages apply to all hand cards

### DIFF
--- a/main.py
+++ b/main.py
@@ -5555,7 +5555,7 @@ class NepBot(NepBotClass):
                             except Exception as ex:
                                 self.message(channel, "Could not process image. %s. Check the URL yourself and if it is invalid reject their request." % str(ex), isWhisper)
                                 return
-                            cur.execute("UPDATE has_waifu SET custom_image = %s WHERE userid = %s AND waifuid = %s", [hostedURL, request[3], request[5]])
+                            cur.execute("UPDATE has_waifu SET custom_image = %s WHERE userid = %s AND waifuid = %s AND rarity = %s", [hostedURL, request[3], request[5], godRarity])
 
                             queryArgs = [tags['user-id'], current_milli_time(), request[0]]
                             cur.execute("UPDATE godimage_requests SET state = 'accepted_single', moderatorid = %s, updated = %s WHERE id = %s", queryArgs)


### PR DESCRIPTION
It is possible to request a godimage when more than one copy of the card
exists in a player's hand.
The code updated the godimage for *all* copies of the card for which a
godimage was requested in the hand of the player that made the request.
This commit fixes that behavior so that the single godimage is only
applied to the card at God rarity.

This would allow the creation of Mythical and below cards with the single
godimage.
The lower rarity godimaged cards are non-transferable due to the trade
code doing an explicit rarity check on transfer and bounties cause the
creation of a new card anyway.

---

This has happened with [385] in Honbuk's hand. I'd recommend treating this like a real life TCG misprint, but that's ultimately a policy question.

Fix untested (my personal schema still predates the July update) but looks correct to me.