### PR TITLE
main/website: fix firstGod determination

### DIFF
--- a/main.py
+++ b/main.py
@@ -905,7 +905,7 @@ def getWaifuOwners(id, rarity):
         baseRarityName = config["rarity%dName" % rarity]
         godRarity = int(config["numNormalRarities"]) - 1
         cur.execute(
-            "SELECT users.name, c1.rarity, IF(c1.boosterid IS NOT NULL, 1, 0), IF(c1.rarity = %s AND NOT EXISTS(SELECT id FROM cards c2 WHERE c2.rarity = %s AND c2.waifuid = c1.waifuid AND (c2.created < c1.created OR (c2.created=c1.created AND c2.id < c1.id))), 1, 0) AS firstGod FROM cards c1 JOIN users ON c1.userid = users.id WHERE c1.waifuid = %s AND c1.userid IS NOT NULL ORDER BY firstGod DESC, c1.rarity DESC, c1.created ASC, users.name ASC",
+            "SELECT users.name, c1.rarity, IF(c1.boosterid IS NOT NULL, 1, 0), IF(c1.rarity = %s AND NOT EXISTS(SELECT id FROM cards c2 WHERE (c2.boosterid IS NOT NULL OR c2.userid IS NOT NULL) AND c2.rarity = %s AND c2.waifuid = c1.waifuid AND (c2.created < c1.created OR (c2.created=c1.created AND c2.id < c1.id))), 1, 0) AS firstGod FROM cards c1 JOIN users ON c1.userid = users.id WHERE c1.waifuid = %s AND c1.userid IS NOT NULL ORDER BY firstGod DESC, c1.rarity DESC, c1.created ASC, users.name ASC",
             [godRarity, godRarity, id])
         allOwners = cur.fetchall()
 

--- a/website.js
+++ b/website.js
@@ -114,7 +114,7 @@ function hand(req, res, query) {
     }
 
     con.query("SELECT waifus.*, c1.rarity, c1.customImage, c1.id as cardid, c1.tradeableAt, c1.created, " +
-        "IF(c1.rarity = 7 AND NOT EXISTS(SELECT id FROM cards c2 WHERE c2.rarity = 7 AND c2.waifuid = c1.waifuid AND (c2.created < c1.created OR (c2.created=c1.created AND c2.id < c1.id))), 1, 0) AS firstGod FROM waifus JOIN cards c1 ON waifus.id = c1.waifuid JOIN users ON " +
+        "IF(c1.rarity = 7 AND NOT EXISTS(SELECT id FROM cards c2 WHERE (c2.boosterid IS NOT NULL OR c2.userid IS NOT NULL) AND c2.rarity = 7 AND c2.waifuid = c1.waifuid AND (c2.created < c1.created OR (c2.created=c1.created AND c2.id < c1.id))), 1, 0) AS firstGod FROM waifus JOIN cards c1 ON waifus.id = c1.waifuid JOIN users ON " +
         "c1.userid = users.id WHERE users.name = ? AND c1.boosterid IS NULL ORDER BY COALESCE(c1.sortValue, 32000) ASC, (c1.rarity < 8) DESC, waifus.id ASC, c1.rarity ASC, c1.id ASC", query.user, function (err, result) {
         if (err) throw err;
         let wantJSON = false;


### PR DESCRIPTION
This changes the query to account for previously died cards (i.e. ones
with both userid and boosterid set to NULL).
Otherwise, a dead God card could block the only God in existence.