### PR TITLE
Don't require user for link to rules in header

### DIFF
--- a/templates/includes/header.ejs
+++ b/templates/includes/header.ejs
@@ -49,7 +49,7 @@
                 </li>
             <% } %>
             <li class="nav-item <% if(currentPage === 'rules') { %>active<% } %>">
-                <a class="nav-link user-required" href="/rules?user=<%= user %>">Rules</a>
+                <a class="nav-link" href="/rules?user=<%= user %>">Rules</a>
             </li>
             <li class="nav-item">
                 <a class="nav-link disabled">Super Secret Admin-Panel</a>


### PR DESCRIPTION
Should address https://github.com/Marenthyu/NepBot/issues/100

Just did the same thing that the Sets link does.